### PR TITLE
Add an -e/--eval option, and automatically detect file name args

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,27 @@ $ bb '(slurp "https://www.clojure.org")' | bb '(subs *in* 0 50)'
 "<!doctype html><html itemscope=\"\" itemtype=\"http:/"
 ```
 
-## Test
+## Developing Babashka
+
+To work on Babashka itself make sure Git submodules are checked out.
+
+``` shellsession
+$ git clone https://github.com/borkdude/babashka --recursive
+```
+
+To update later on:
+
+``` shellsession
+$ git submodule update --recursive
+```
+
+You need [Leiningen](https://leiningen.org/), and for building binaries you need GraalVM.
+
+### REPL
+
+`lein repl` will get you a standard REPL/nREPL connection. To work on tests use `lein with-profiles +test repl`.
+
+### Test
 
 Test on the JVM:
 
@@ -334,22 +354,7 @@ Test the native version:
 
     BABASHKA_TEST_ENV=native script/test
 
-## Build
-
-You will need leiningen and GraalVM.
-
-This repo contains a submodule, so you will have clone that too.  If you're
-doing that for the first time:
-
-``` shellsession
-$ git submodule update --init --recursive
-```
-
-and for subsequent updates:
-
-``` shellsession
-$ git submodule update --recursive
-```
+### Build
 
 To build this project, set `$GRAALVM_HOME` to the GraalVM distribution directory.
 

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -10,6 +10,26 @@
 (defn bb [input & args]
   (edn/read-string (apply test-utils/bb (str input) (map str args))))
 
+(deftest parse-opts-test
+  (is (= {:expression "(println 123)"}
+         (main/parse-opts ["-e" "(println 123)"])))
+
+  (is (= {:expression "(println 123)"}
+         (main/parse-opts ["--eval" "(println 123)"])))
+
+  (testing "distinguish automatically between expression or file name"
+    (is (= {:expression "(println 123)"
+            :command-line-args []}
+           (main/parse-opts ["(println 123)"])))
+
+    (is (= {:file "src/babashka/main.clj"
+            :command-line-args []}
+           (main/parse-opts ["src/babashka/main.clj"])))
+
+    (is (= {:expression "does-not-exist"
+            :command-line-args []}
+           (main/parse-opts ["does-not-exist"])))))
+
 (deftest main-test
   (testing "-io behaves as identity"
     (= "foo\nbar\n" (test-utils/bb "foo\nbar\n" "-io" "*in*")))


### PR DESCRIPTION
When an argument is a file name (i.e. the file exists), then treat it as a file,
rather than as an expression.

Update dev docs.

Closes #59