### PR TITLE
Added more String parsers

### DIFF
--- a/src/babashka/impl/Boolean.clj
+++ b/src/babashka/impl/Boolean.clj
@@ -1,0 +1,15 @@
+(ns babashka.impl.Boolean
+  {:no-doc true}
+  (:refer-clojure :exclude [list]))
+
+(set! *warn-on-reflection* true)
+
+(defn parseBoolean [^String x]
+  (Boolean/parseBoolean x))
+
+(def boolean-bindings
+  {'Boolean/parseBoolean parseBoolean})
+
+(comment
+  
+  )

--- a/src/babashka/impl/Double.clj
+++ b/src/babashka/impl/Double.clj
@@ -1,0 +1,15 @@
+(ns babashka.impl.Double
+  {:no-doc true}
+  (:refer-clojure :exclude [list]))
+
+(set! *warn-on-reflection* true)
+
+(defn parseDouble [^String x]
+  (Double/parseDouble x))
+
+(def double-bindings
+  {'Double/parseDouble parseDouble})
+
+(comment
+  
+  )

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -3,6 +3,7 @@
   (:require
    [babashka.impl.File :refer [file-bindings]]
    [babashka.impl.Integer :refer [integer-bindings]]
+   [babashka.impl.Double :refer [double-bindings]]
    [babashka.impl.Pattern :refer [pattern-bindings]]
    [babashka.impl.System :refer [system-bindings]]
    [babashka.impl.Thread :refer [thread-bindings]]
@@ -153,6 +154,7 @@ Everything after that is bound to *command-line-args*."))
          file-bindings
          thread-bindings
          integer-bindings
+         double-bindings
          exception-bindings
          pattern-bindings))
 

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -4,6 +4,7 @@
    [babashka.impl.File :refer [file-bindings]]
    [babashka.impl.Integer :refer [integer-bindings]]
    [babashka.impl.Double :refer [double-bindings]]
+   [babashka.impl.Boolean :refer [boolean-bindings]]
    [babashka.impl.Pattern :refer [pattern-bindings]]
    [babashka.impl.System :refer [system-bindings]]
    [babashka.impl.Thread :refer [thread-bindings]]
@@ -155,6 +156,7 @@ Everything after that is bound to *command-line-args*."))
          thread-bindings
          integer-bindings
          double-bindings
+         boolean-bindings
          exception-bindings
          pattern-bindings))
 


### PR DESCRIPTION
Added:

* Double/parseDouble
* Boolean/parseBoolean

I need this for a project where I parse command-line options with these types. I figured `Float/parseFloat` is redundant because of the implicit cast of Float to Double.

Note that I wasn't able to run the tests:

```
script/test
Syntax error (FileNotFoundException) compiling at (babashka/impl/socket_repl.clj:1:1).
Could not locate sci/impl/interpreter__init.class, sci/impl/interpreter.clj or sci/impl/interpreter.cljc on classpath.

Full report at:
/var/folders/ck/9zqvs0zx5vsf2bc7rvv1pwc40000gn/T/clojure-2853884920458488806.edn
Tests failed.
```
I've basically copied the `Integer.clj` namespace and adapted it to my best knowledge.