### PR TITLE
Add FileTime and TimeUnit for working with times on file attributes

### DIFF
--- a/reflection.json
+++ b/reflection.json
@@ -224,6 +224,11 @@
   "allPublicFields" : true,
   "allPublicConstructors" : true
 }, {
+  "name" : "java.nio.file.attribute.FileTime",
+  "allPublicMethods" : true,
+  "allPublicFields" : true,
+  "allPublicConstructors" : true
+}, {
   "name" : "java.nio.file.attribute.PosixFilePermission",
   "allPublicMethods" : true,
   "allPublicFields" : true,
@@ -355,6 +360,11 @@
   "allPublicConstructors" : true
 }, {
   "name" : "java.util.concurrent.LinkedBlockingQueue",
+  "allPublicMethods" : true,
+  "allPublicFields" : true,
+  "allPublicConstructors" : true
+}, {
+  "name" : "java.util.concurrent.TimeUnit",
   "allPublicMethods" : true,
   "allPublicFields" : true,
   "allPublicConstructors" : true

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -50,6 +50,7 @@
                       java.nio.file.Paths
                       java.nio.file.StandardCopyOption
                       java.nio.file.attribute.FileAttribute
+                      java.nio.file.attribute.FileTime
                       java.nio.file.attribute.PosixFilePermission
                       java.nio.file.attribute.PosixFilePermissions
                       java.time.format.DateTimeFormatter
@@ -77,6 +78,7 @@
                       java.util.Base64$Decoder
                       java.util.Base64$Encoder
                       java.util.UUID
+                      java.util.concurrent.TimeUnit
                       java.util.zip.InflaterInputStream
                       java.util.zip.DeflaterInputStream
                       java.util.zip.GZIPInputStream


### PR DESCRIPTION
Needed in order to work with file attributes that include times.

```
user=> (-> (File. "src") .toPath (java.nio.file.Files/readAttributes "*" (make-array java.nio.file.LinkOption 0)) (get "lastModifiedTime"))
#object[java.nio.file.attribute.FileTime 0x52e0cdac "2020-01-01T23:34:20Z"]
user=> (-> (File. "src") .toPath (java.nio.file.Files/readAttributes "*" (make-array java.nio.file.LinkOption 0)) (get "lastModifiedTime") .toInstant)
#object[java.time.Instant 0x29d3a09e "2020-01-01T23:34:20Z"]
user=> (-> (File. "src") .toPath (java.nio.file.Files/readAttributes "*" (make-array java.nio.file.LinkOption 0)) (get "lastModifiedTime") (.to java.util.concurrent.TimeUnit/NANOSECONDS))
1577921660000000000
```
