### PR TITLE
Using ubuntu:bionic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,6 @@ RUN ./script/compile
 RUN cp bb /usr/local/bin
 
 
-FROM alpine:3.9
-
-# See https://github.com/sgerrand/alpine-pkg-glibc
-RUN apk --no-cache add ca-certificates curl
-RUN curl -o /etc/apk/keys/sgerrand.rsa.pub -sL https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-RUN curl -sLO https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.29-r0/glibc-2.29-r0.apk
-RUN apk add glibc-2.29-r0.apk
+FROM ubuntu:bionic
 COPY --from=BASE /usr/local/bin/bb /usr/local/bin
-ENV LD_LIBRARY_PATH /lib
 CMD ["bb"]


### PR DESCRIPTION
I find that one has to jump through a lot of hoop in order to get glibc and/or libstdc++ working on Alpine. It might be easier to use a popular base image which everyone probably has it in the local cache.

Related:
* https://github.com/sgerrand/alpine-pkg-glibc/issues/80
* https://gitlab.alpinelinux.org/alpine/aports/issues/4903

Fix #259 