### PR TITLE
Support AWS Lambda custom runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1106,7 +1106,7 @@ Your command line args: (1 2 3)
 
 ## Package babashka script as a AWS Lambda
 
-AWS Lambda runtime doesn't support signals, therefore babashka has to disable handling of the SIGPIPE. This can be done by setting `DISABLE_PIPE_SIGNAL_HANDLING` to `true`.
+AWS Lambda runtime doesn't support signals, therefore babashka has to disable handling of the SIGPIPE. This can be done by setting `BABASHKA_DISABLE_PIPE_HANDLER` to `true`.
 
 ## Thanks
 

--- a/README.md
+++ b/README.md
@@ -1104,6 +1104,10 @@ $ docker run --rm script 1 2 3
 Your command line args: (1 2 3)
 ```
 
+## Package babashka script as a AWS Lambda
+
+AWS Lambda runtime doesn't support signals, therefore babashka has to disable handling of the SIGPIPE. This can be done by setting `DISABLE_PIPE_SIGNAL_HANDLING` to `true`.
+
 ## Thanks
 
 - [adgoji](https://www.adgoji.com/) for financial support

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -289,7 +289,8 @@ Everything after that is bound to *command-line-args*."))
 
 (defn main
   [& args]
-  (handle-pipe!)
+  (when-not (Boolean/valueOf ^String (System/getenv "DISABLE_PIPE_SIGNAL_HANDLING"))
+    (handle-pipe!))
   #_(binding [*out* *err*]
       (prn "M" (meta (get bindings 'future))))
   (binding [*unrestricted* true]

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -289,7 +289,7 @@ Everything after that is bound to *command-line-args*."))
 
 (defn main
   [& args]
-  (when-not (Boolean/valueOf ^String (System/getenv "DISABLE_PIPE_SIGNAL_HANDLING"))
+  (when-not (Boolean/valueOf ^String (System/getenv "BABASHKA_DISABLE_PIPE_HANDLER"))
     (handle-pipe!))
   #_(binding [*out* *err*]
       (prn "M" (meta (get bindings 'future))))


### PR DESCRIPTION
AWS Lambda doesn't support signal [handling](https://github.com/oracle/graal/issues/841), e.g. [here](https://github.com/quarkusio/quarkus/issues/4262). Therefore, in order for babashka to work, it is needed to disable the handling of SIGPIPE.

I propose to introduce an environment variable to alter the default behaviour and disable the handling of SIGPIPE: `BABASHKA_DISABLE_PIPE_HANDLER`. 

An example project that runs babashka script in AWS Lambda https://github.com/dainiusjocas/babashka-lambda.