### PR TITLE
Added an example about using deps.clj script to produce the classpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,28 @@ $ bb --classpath src --main my.namespace
 Hello from my namespace!
 ```
 
+So if you have a larger script with a classic Clojure project layout like
+
+```shellsession
+$ tree -L 3
+├── deps.edn
+├── README
+├── src
+│   └── project_namespace
+│       ├── main.clj
+│       └── utilities.clj
+└── test
+    └── project_namespace
+        ├── test_main.clj
+        └── test_utilities.clj
+```
+Then you can tell Babashka to include both the `src` and `test`
+folders in the classpath and start a socket REPL by running:
+
+```shellsession
+$ bb --classpath src:test --socket-repl 1666
+```
+
 Note that you can use the `clojure` tool to produce classpaths and download dependencies:
 
 ``` shellsession
@@ -511,6 +533,46 @@ user=> (mgs/-main)
 Hello from gist script!
 nil
 ```
+
+You can also use for example `deps.clj` to produce the classpath for a
+`babashka` REPL:
+
+```shellsession
+$ cat script/start-repl.sh
+#!/bin/sh -e
+git_root=$(git rev-parse --show-toplevel)
+export BABASHKA_CLASSPATH=$("$git_root"/script/deps.clj -Spath)
+bb --socket-repl 1666
+$ ./script/start-repl.sh
+Babashka socket REPL started at localhost:1666
+```
+
+Now, given that your `deps.edn` and source tree looks something like
+
+```shellsession
+$ cat deps.edn
+{:paths ["src" "test"]
+ :deps  {}}
+$ tree -L 3
+├── deps.edn
+├── README
+├── script
+│   ├── deps.clj
+│   └── start-repl.sh
+├── src
+│   └── project_namespace
+│       ├── main.clj
+│       └── utilities.clj
+└── test
+    └── project_namespace
+        ├── test_main.clj
+        └── test_utilities.clj
+
+```
+
+you should now be able to `(require '[multi-machine-rsync.utilities :as util])`
+in your REPL and the source code in `/src/multi_machine_rsync/utilities.clj`
+will be evaluated and made available through the symbol `util`.
 
 ## Uberscript
 


### PR DESCRIPTION
I found the examples using aliases hard to understand and didn't want to spin up an entire clojure instance to calculate the classpath.

Feel free to do with it as you want.