### PR TITLE
Send bencode using BufferedOutputStream

### DIFF
--- a/src/babashka/impl/nrepl_server.clj
+++ b/src/babashka/impl/nrepl_server.clj
@@ -7,7 +7,7 @@
             [sci.impl.interpreter :refer [eval-string*]]
             [sci.impl.utils :as sci-utils]
             [sci.impl.vars :as vars])
-  (:import [java.io StringWriter OutputStream InputStream PushbackInputStream EOFException]
+  (:import [java.io StringWriter OutputStream InputStream PushbackInputStream EOFException BufferedOutputStream]
            [java.net ServerSocket]))
 
 (set! *warn-on-reflection* true)
@@ -166,7 +166,8 @@
   (let [client-socket (.accept listener)
         in (.getInputStream client-socket)
         in (PushbackInputStream. in)
-        out (.getOutputStream client-socket)]
+        out (.getOutputStream client-socket)
+        out (BufferedOutputStream. out)]
     (when @dev? (println "Connected."))
     (sci/future
       (sci/binding


### PR DESCRIPTION
This new implementation is faster because you only flush when you issue `.flush`, or until the buffer is full. Some simple experiments with Chlorine confirmed that small messages are being received in a whole block, instead of fragmented.