### PR TITLE
Add Float class for use in scripts

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -107,6 +107,7 @@
           java.lang.Comparable
           java.lang.Double
           java.lang.Exception
+          java.lang.Float
           java.lang.Integer
           java.lang.Long
           java.lang.Number


### PR DESCRIPTION
I'd like to `bb '(Float/parseFloat "7.5")'` and was unable to. I think this is all that is needed to enable this. Cheers