### PR TITLE
Disable signal handlers on AWS lambdas via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,8 +803,8 @@ repo](https://github.com/babashka/babashka.pods).
 ## Package babashka script as a AWS Lambda
 
 AWS Lambda runtime doesn't support signals, therefore babashka has to disable
-handling of the SIGPIPE. This can be done by setting
-`BABASHKA_DISABLE_PIPE_SIGNAL_HANDLER` to `true`.
+handling of SIGINT and SIGPIPE. This can be done by setting
+`BABASHKA_DISABLE_SIGNAL_HANDLERS` to `true`.
 
 ## Articles, podcasts and videos
 

--- a/src/babashka/impl/pipe_signal_handler.clj
+++ b/src/babashka/impl/pipe_signal_handler.clj
@@ -9,7 +9,7 @@
   (identical? :PIPE @pipe-state))
 
 (defn handle-pipe! []
-  (when-not (= "true" (System/getenv "BABASHKA_DISABLE_PIPE_SIGNAL_HANDLER"))
+  (when-not (= "true" (System/getenv "BABASHKA_DISABLE_SIGNAL_HANDLERS"))
     (Signal/handle
      (Signal. "PIPE")
      (reify SignalHandler

--- a/src/babashka/impl/sigint_handler.clj
+++ b/src/babashka/impl/sigint_handler.clj
@@ -6,7 +6,7 @@
 (set! *warn-on-reflection* true)
 
 (defn handle-sigint! []
-  (when-not (= "true" (System/getenv "BABASHKA_DISABLE_PIPE_SIGNAL_HANDLER"))
+  (when-not (= "true" (System/getenv "BABASHKA_DISABLE_SIGNAL_HANDLERS"))
     (Signal/handle
      (Signal. "INT")
      (reify SignalHandler

--- a/src/babashka/impl/sigint_handler.clj
+++ b/src/babashka/impl/sigint_handler.clj
@@ -6,9 +6,10 @@
 (set! *warn-on-reflection* true)
 
 (defn handle-sigint! []
-  (Signal/handle
-   (Signal. "INT")
-   (reify SignalHandler
-     (handle [_ _]
-       ;; This is needed to run shutdown hooks on interrupt, System/exit triggers those
-       (System/exit 0)))))
+  (when-not (= "true" (System/getenv "BABASHKA_DISABLE_PIPE_SIGNAL_HANDLER"))
+    (Signal/handle
+     (Signal. "INT")
+     (reify SignalHandler
+       (handle [_ _]
+         ;; This is needed to run shutdown hooks on interrupt, System/exit triggers those
+         (System/exit 0))))))


### PR DESCRIPTION
The introduction of shutdown hooks from v0.0.81 prevents babashka from running in an AWS lambda. This PR allows disabling the hook through the same env var for disabling the pipe signal handler and renames the env variable for simplicity. 