### PR TITLE
Add support for clojure.data.generators

### DIFF
--- a/script/lib_tests/clojure_data_generators_test
+++ b/script/lib_tests/clojure_data_generators_test
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if [ "$BABASHKA_TEST_ENV" = "native" ]; then
+    BB_CMD="./bb"
+else
+    BB_CMD="lein bb"
+fi
+
+export BABASHKA_CLASSPATH
+BABASHKA_CLASSPATH=$(clojure -Sdeps '{:deps {org.clojure/data.generators {:mvn/version "1.0.0"}}}' -Spath)
+
+$BB_CMD -cp "$BABASHKA_CLASSPATH:test-resources/lib_tests" -e "
+(require '[clojure.data.generators-test])
+(require '[clojure.test :as t])
+(let [{:keys [:test :pass :fail :error]} (t/run-tests 'clojure.data.generators-test)]
+  (when-not (pos? test)
+    (System/exit 1))
+  (System/exit (+ fail error)))
+"

--- a/script/run_lib_tests
+++ b/script/run_lib_tests
@@ -26,3 +26,4 @@ script/lib_tests/clojure_data_zip_test
 script/lib_tests/cljc_java_time_test
 script/lib_tests/camel_snake_kebab_test
 script/lib_tests/aero_test
+script/lib_tests/clojure_data_generators_test

--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -120,6 +120,7 @@
           java.lang.ProcessBuilder$Redirect
           java.lang.Runtime
           java.lang.RuntimeException
+          java.lang.Short
           java.lang.String
           java.lang.StringBuilder
           java.lang.System
@@ -193,6 +194,7 @@
           java.util.jar.JarFile
           java.util.jar.JarEntry
           java.util.jar.JarFile$JarFileEntry
+          java.util.Random
           java.util.regex.Pattern
           java.util.Base64
           java.util.Base64$Decoder

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -400,6 +400,7 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
   '{ArithmeticException java.lang.ArithmeticException
     AssertionError java.lang.AssertionError
     BigDecimal java.math.BigDecimal
+    BigInteger java.math.BigInteger
     Boolean java.lang.Boolean
     Byte java.lang.Byte
     Character java.lang.Character
@@ -421,6 +422,7 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
     RuntimeException java.lang.RuntimeException
     Process        java.lang.Process
     ProcessBuilder java.lang.ProcessBuilder
+    Short java.lang.Short
     String java.lang.String
     StringBuilder java.lang.StringBuilder
     System java.lang.System

--- a/test-resources/lib_tests/clojure/data/generators_test.clj
+++ b/test-resources/lib_tests/clojure/data/generators_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.data.generators :as gen]
             [clojure.test :refer (deftest is)]))
 
-;; REVIEW needed to add these vars. Missing in Babashka?
-(def ^:dynamic *print-length* nil)
+;; TODO add *print-level* to Sci https://github.com/borkdude/sci/issues/351
 (def ^:dynamic *print-level* nil)
 
 (defn print-read-roundtrip

--- a/test-resources/lib_tests/clojure/data/generators_test.clj
+++ b/test-resources/lib_tests/clojure/data/generators_test.clj
@@ -1,0 +1,35 @@
+(ns clojure.data.generators-test
+  (:require [clojure.data.generators :as gen]
+            [clojure.test :refer (deftest is)]))
+
+(defn print-read-roundtrip
+  [o]
+  (binding [*print-length* nil
+            *print-level* nil]
+    (-> o pr-str read-string)))
+
+(defn check-print-read-roundtrip
+  [o]
+  (let [o2 (print-read-roundtrip o)]
+    (when-not (= o o2)
+      (throw (ex-info "Value cannot roundtrip, see ex-data" {:value o :roundtrip o2})))))
+
+(deftest test-print-read-roundtrip
+  (dotimes [_ 50]
+    (check-print-read-roundtrip (gen/anything))))
+
+(deftest test-shuffle
+  (dotimes [_ 50]
+    (let [coll (gen/vec gen/anything)
+          shuf (gen/shuffle coll)]
+      (is (= (into #{} coll)
+             (into #{} shuf))))))
+
+(deftest test-reservoir-sample-consistency
+  (dotimes [n 50]
+    (let [coll (range 100)
+          sample-1 (binding [gen/*rnd* (java.util.Random. n)]
+                     (gen/reservoir-sample 10 coll))
+          sample-2 (binding [gen/*rnd* (java.util.Random. n)]
+                     (gen/reservoir-sample 10 coll))]
+      (is (= sample-1 sample-2)))))

--- a/test-resources/lib_tests/clojure/data/generators_test.clj
+++ b/test-resources/lib_tests/clojure/data/generators_test.clj
@@ -2,6 +2,10 @@
   (:require [clojure.data.generators :as gen]
             [clojure.test :refer (deftest is)]))
 
+;; REVIEW needed to add these vars. Missing in Babashka?
+(def ^:dynamic *print-length* nil)
+(def ^:dynamic *print-level* nil)
+
 (defn print-read-roundtrip
   [o]
   (binding [*print-length* nil

--- a/test-resources/lib_tests/clojure/data/generators_test.clj
+++ b/test-resources/lib_tests/clojure/data/generators_test.clj
@@ -2,9 +2,6 @@
   (:require [clojure.data.generators :as gen]
             [clojure.test :refer (deftest is)]))
 
-;; TODO add *print-level* to Sci https://github.com/borkdude/sci/issues/351
-(def ^:dynamic *print-level* nil)
-
 (defn print-read-roundtrip
   [o]
   (binding [*print-length* nil


### PR DESCRIPTION
I would like to use `clojure.data.generators` in a babashka script to deterministically generate data.

These changes are required to load `clojure.data.generators`: 
```
bb -e '(eval (read-string (str "(do" (slurp "https://raw.githubusercontent.com/clojure/data.generators/master/src/main/clojure/clojure/data/generators.clj")
```

This adds the missing classes `java.util.Random` and `java.lang.Short`
This adds the missing aliases `BigInteger` and `Short`

`double-array` and `short-array` are added via https://github.com/borkdude/sci/pull/350

I didn't add unit tests as I'm not sure what a good test would be other than loading the generator namespace.