### PR TITLE
[#495] add clojure.java.browse/browse-url

### DIFF
--- a/src/babashka/impl/clojure/java/browse.clj
+++ b/src/babashka/impl/clojure/java/browse.clj
@@ -18,7 +18,7 @@
     (case os
       :mac (sh "/usr/bin/open" url)
       :linux (sh "/usr/bin/xdg-open" url)
-      :windows (sh "start" url))))
+      :windows (sh "cmd" "/C" "start" url))))
 
 (def browse-namespace
   {'browse-url browse-url})

--- a/src/babashka/impl/clojure/java/browse.clj
+++ b/src/babashka/impl/clojure/java/browse.clj
@@ -1,0 +1,25 @@
+(ns babashka.impl.clojure.java.browse
+  {:no-doc true}
+  (:require [clojure.java.shell :refer [sh]]
+            [clojure.string :as str]))
+
+(def os
+  (let [os-name (System/getProperty "os.name")
+        os-name (str/lower-case os-name)]
+    (cond (str/starts-with? os-name "mac os x")
+          :mac
+          (str/includes? os-name "linux")
+          :linux
+          (str/includes? os-name "win")
+          :windows)))
+
+(defn browse-url [url]
+  (let [url (str url)]
+    (case os
+      :mac (sh "/usr/bin/open" url)
+      :linux (sh "/usr/bin/xdg-open" url)
+      :windows (sh "start" url))))
+
+(def browse-namespace
+  {'browse-url browse-url})
+

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -6,6 +6,7 @@
    [babashka.impl.classes :as classes]
    [babashka.impl.classpath :as cp]
    [babashka.impl.clojure.core :as core :refer [core-extras]]
+   [babashka.impl.clojure.java.browse :refer [browse-namespace]]
    [babashka.impl.clojure.java.io :refer [io-namespace]]
    [babashka.impl.clojure.java.shell :refer [shell-namespace]]
    [babashka.impl.clojure.main :as clojure-main :refer [demunge]]
@@ -367,7 +368,8 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
        'babashka.curl curl-namespace
        'babashka.pods pods/pods-namespace
        'bencode.core bencode-namespace
-       'flatland.ordered.map ordered-map-ns}
+       'flatland.ordered.map ordered-map-ns
+       'clojure.java.browse browse-namespace}
     features/xml?  (assoc 'clojure.data.xml @(resolve 'babashka.impl.xml/xml-namespace))
     features/yaml? (assoc 'clj-yaml.core @(resolve 'babashka.impl.yaml/yaml-namespace))
     features/jdbc? (assoc 'next.jdbc @(resolve 'babashka.impl.jdbc/njdbc-namespace)


### PR DESCRIPTION
Fixes #495. 
cc @lread

One issue remains to be fixed on Windows:
```
C:\Users\borkdude\Downloads>bb -e "(require '[clojure.java.browse :refer [browse-url]]) (browse-url \"https://babashka.org\")"
java.io.IOException: Cannot run program "start": CreateProcess error=2, The system cannot find the file specified [at line 1, column 54]
```

This seems to work:

```
> bb -e "(require '[clojure.java.shell :refer [sh]]) (sh \"cmd.exe\" \"/C\" \"start\" \"https://babashka.org\")"
{:exit 0, :out "", :err ""}
```