### PR TITLE
Add java class to support circle/bond

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -80,7 +80,8 @@
                                         :parameterTypes ["java.lang.String","java.util.Locale","java.lang.ClassLoader"]}]})))
 
 (def classes
-  `{:all [clojure.lang.BigInt
+  `{:all [clojure.lang.ArityException
+          clojure.lang.BigInt
           clojure.lang.ExceptionInfo
           java.io.BufferedReader
           java.io.BufferedWriter


### PR DESCRIPTION
Hi borkdude. I'd like to be able to use https://github.com/circleci/bond for a bb testing tool I'm writing. Is this ok? I don't know the guidelines on what classes are ok to add but I figured anything with clojure.* was fair game. 
I'm happy to add bond to libraries.md and lib_tests/. Does one just create a new directory in test-resources/lib_tests/ and copy over tests from the library?

Cheers