### PR TITLE
[doc] set classpath in the nrepl helper script

### DIFF
--- a/doc/repl.md
+++ b/doc/repl.md
@@ -99,7 +99,9 @@ you can easily write a script that launches the server and writes the file:
 (require '[babashka.wait :as wait])
 
 (let [nrepl-port (with-open [sock (ServerSocket. 0)] (.getLocalPort sock))
-      pb (doto (ProcessBuilder. (into ["bb" "--nrepl-server" (str nrepl-port)]
+      cp (str/join File/pathSeparatorChar ["src" "test"])
+      pb (doto (ProcessBuilder. (into ["bb" "--nrepl-server" (str nrepl-port)
+                                       "--classpath" cp]
                                       *command-line-args*))
            (.redirectOutput ProcessBuilder$Redirect/INHERIT))
       proc (.start pb)]


### PR DESCRIPTION
In the suggested helper script for starting the nrepl server, set the classpath to include `src` and `test` dirs, so that :require works correctly when the script is run from the project root.


```
;; <skipped>
(let [nrepl-port (with-open [sock (ServerSocket. 0)] (.getLocalPort sock))
      cp (str/join File/pathSeparatorChar ["src" "test"])
      pb (doto (ProcessBuilder. (into ["bb" "--nrepl-server" (str nrepl-port)
                                       "--classpath" cp]
                                      *command-line-args*))
           (.redirectOutput ProcessBuilder$Redirect/INHERIT))
      proc (.start pb)]
  (wait/wait-for-port "localhost" nrepl-port)
  (spit ".nrepl-port" nrepl-port)
  (.deleteOnExit (File. ".nrepl-port"))
  (.waitFor proc))
```