### PR TITLE
Added lib tests for version-clj

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -57,4 +57,5 @@
                          org.clojure/data.generators {:mvn/version "1.0.0"}
                          honeysql/honeysql {:mvn/version "1.0.444"}
                          minimallist/minimallist {:mvn/version "0.0.6"}
-                         circleci/bond {:mvn/version "0.4.0"}}}}}
+                         circleci/bond {:mvn/version "0.4.0"}
+                         version-clj/version-clj {:mvn/version "0.1.2"}}}}}

--- a/test-resources/lib_tests/babashka/run_all_libtests.clj
+++ b/test-resources/lib_tests/babashka/run_all_libtests.clj
@@ -181,6 +181,12 @@
 ;;;; bond
 (test-namespaces 'bond.test.james)
 
+;;;; version-clj
+(test-namespaces 'version-clj.compare-test
+                 'version-clj.core-test
+                 'version-clj.split-test
+                 'version-clj.via-use-test)
+
 ;;;; final exit code
 
 (let [{:keys [:test :fail :error] :as m} @status]

--- a/test-resources/lib_tests/version_clj/compare_test.cljc
+++ b/test-resources/lib_tests/version_clj/compare_test.cljc
@@ -1,0 +1,59 @@
+(ns version-clj.compare-test
+  (:require [clojure.test :refer [deftest are]]
+            [version-clj.compare :refer [version-compare]]))
+
+(deftest t-version-compare
+  (are [v0 v1 r] (= (version-compare v0 v1) r)
+       ;; Numeric Comparison
+       "1.0.0"          "1.0.0"           0
+       "1.0.0"          "1.0"             0
+       "1.0.1"          "1.0"             1
+       "1.0.0"          "1.0.1"          -1
+       "1.0.0"          "0.9.2"           1
+       "0.9.2"          "0.9.3"          -1
+       "0.9.2"          "0.9.1"           1
+       "0.9.5"          "0.9.13"         -1
+       "10.2.0.3.0"     "11.2.0.3.0"     -1
+       "10.2.0.3.0"     "5.2.0.3.0"       1
+       "1.0.0-SNAPSHOT" "1.0.1-SNAPSHOT" -1
+       "1.0.0-alpha"    "1.0.1-beta"     -1
+       "1.1-dolphin"    "1.1.1-cobra"    -1
+
+       ;; Lexical Comparison
+       "1.0-alpaca"     "1.0-bermuda"    -1
+       "1.0-alpaca"     "1.0-alpaci"     -1
+       "1.0-dolphin"    "1.0-cobra"       1
+
+       ;; Qualifier Comparison
+       "1.0.0-alpha"    "1.0.0-beta"     -1
+       "1.0.0-beta"     "1.0.0-alpha"     1
+       "1.0.0-alpaca"   "1.0.0-beta"     -1
+       "1.0.0-final"    "1.0.0-milestone" 1
+
+       ;; Qualifier/Numeric Comparison
+       "1.0.0-alpha1"   "1.0.0-alpha2"   -1
+       "1.0.0-alpha5"   "1.0.0-alpha23"  -1
+       "1.0-RC5"        "1.0-RC20"       -1
+       "1.0-RC11"       "1.0-RC6"         1
+
+       ;; Releases are newer than SNAPSHOTs
+       "1.0.0"          "1.0.0-SNAPSHOT"  1
+       "1.0.0-SNAPSHOT" "1.0.0-SNAPSHOT"  0
+       "1.0.0-SNAPSHOT" "1.0.0"          -1
+
+       ;; Releases are newer than qualified versions
+       "1.0.0"          "1.0.0-alpha5"    1
+       "1.0.0-alpha5"   "1.0.0"          -1
+
+       ;; SNAPSHOTS are newer than qualified versions
+       "1.0.0-SNAPSHOT" "1.0.0-RC1"       1
+       "1.0.0-SNAPSHOT" "1.0.1-RC1"      -1
+
+       ;; Some other Formats
+       "9.1-901.jdbc4"   "9.1-901.jdbc3"   1
+       "9.1-901-1.jdbc4" "9.1-901.jdbc4"   1
+
+       ;; Some more zero-extension Tests
+       "1-SNAPSHOT"      "1.0-SNAPSHOT"    0
+       "1-alpha"         "1-alpha0"        0
+       ))

--- a/test-resources/lib_tests/version_clj/core_test.cljc
+++ b/test-resources/lib_tests/version_clj/core_test.cljc
@@ -1,0 +1,25 @@
+(ns version-clj.core-test
+  (:require [clojure.test :refer [deftest are]]
+            [version-clj.core :refer [snapshot? qualified?]]))
+
+(deftest t-snapshot
+  (are [v r] (= (boolean (snapshot? v)) r)
+       "1.0.0"                  false
+       "SNAPSHOT"               true
+       "1-SNAPSHOT"             true
+       "1.0-SNAPSHOT"           true
+       "1.0-SNAPSHOT.2"         true
+       "1.0-NOSNAPSHOT"         false))
+
+(deftest t-qualified
+  (are [v r] (= (boolean (qualified? v)) r)
+       "1.0.0"                  false
+       "SNAPSHOT"               true
+       "1-SNAPSHOT"             true
+       "1.0-SNAPSHOT"           true
+       "1.0-SNAPSHOT.2"         true
+       "1.0-NOSNAPSHOT"         true
+       "1.x.2"                  false
+       "1.2y"                   true
+       "1.y2"                   false
+       "1.y"                    false))

--- a/test-resources/lib_tests/version_clj/split_test.cljc
+++ b/test-resources/lib_tests/version_clj/split_test.cljc
@@ -1,0 +1,22 @@
+(ns version-clj.split-test
+  (:require [clojure.test :refer [deftest are is]]
+            [version-clj.split :refer [version->seq]]))
+
+(deftest t-split
+  (are [version v] (= (version->seq version) v)
+       "1.0.0"          [[1 0 0]]
+       "1.0"            [[1 0]]
+       "1"              [[1]]
+       "1a"             [[1] ["a"]]
+       "1-a"            [[1] ["a"]]
+       "1.0.1-SNAPSHOT" [[1 0 1] ["snapshot"]]
+       "1.0.1-alpha2"   [[1 0 1] ["alpha" 2]]
+       "11.2.0.3.0"     [[11 2 0 3 0]]
+       "1.0-1-0.2-RC"   [[1 [0 1 0] 2] ["rc"]]))
+
+(deftest t-split-with-large-number
+  (is (= (version->seq "0.0.1-20141002100138")
+         [[0 0 1] [20141002100138]]))
+  #?(:clj
+     (let [v (str Long/MAX_VALUE "12345")]
+       (is (= (version->seq v) [[(bigint v)]])))))

--- a/test-resources/lib_tests/version_clj/via_use_test.clj
+++ b/test-resources/lib_tests/version_clj/via_use_test.clj
@@ -1,0 +1,13 @@
+(ns version-clj.via-use-test
+  "Babashka was failing when loading version-clj via `use` and `require`->`:refer`.
+  The unit tests transcribed from version-clj address the require->refer case.
+  This set of tests spot-check that loading via use works for version-clj."
+  (:require [clojure.test :refer [deftest is]]))
+
+(use 'version-clj.core)
+
+(deftest sanity-test
+  (is (= [[1 0 0] ["snapshot"]] (version->seq "1.0.0-SNAPSHOT")))
+  (is (= 0 (version-compare "1.0" "1.0.0")))
+  (is (= -1 (version-compare "1.0-alpha5" "1.0-alpha14")))
+  (is (= 1 (version-compare "1.0-alpha14" "1.0-alpha5"))) )


### PR DESCRIPTION
The version-clj project uses `.cljx` so I hand-transcribed them to `.cljc`.

Tests are from from version-clj v1.0.2:
https://github.com/xsc/version-clj/tree/clojars-0.1.2

Added `version-clj.via-use-test` to verify loading version-clj via `use`.

Verification via: `./script/run_lib_tests`, I observed version-clj tests:
1. failing for `bb` native v0.2.0
2. passing for `./bb` native built from master
3. passing for `lein bb` from master

This should be the final change that closes #565.