### PR TITLE
Add clojure-lanterna

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -83,6 +83,7 @@ Babashka supports the following feature flags:
 | `BABASHKA_FEATURE_POSTGRESQL` | Includes the [PostgresSQL](https://jdbc.postgresql.org/) JDBC driver |  `false` |
 | `BABASHKA_FEATURE_HSQLDB` | Includes the [HSQLDB](http://www.hsqldb.org/) JDBC driver | `false` |
 | `BABASHKA_FEATURE_DATASCRIPT` | Includes [datascript](https://github.com/tonsky/datascript) | `false` |
+| `BABASHKA_FEATURE_LANTERNA` | Includes [clojure-lanterna](https://github.com/babashka/clojure-lanterna) | `false` |
 
 Note that httpkit server is currently experimental, the feature flag could be toggled to `false` in a future release.
 

--- a/doc/build.md
+++ b/doc/build.md
@@ -113,4 +113,14 @@ $ script/uberjar
 $ script/compile
 ```
 
+### Lanterna
+
+To compile babashka with the [babashka/clojure-lanterna](https://github.com/babashka/clojure-lanterna) library:
+
+``` shell
+$ export BABASHKA_FEATURE_LANTERNA=true
+$ script/uberjar
+$ script/compile
+```
+
 Note: there is now a [pod](https://github.com/babashka/babashka-sql-pods) for working with PostgreSQL.

--- a/feature-lanterna/babashka/impl/lanterna.clj
+++ b/feature-lanterna/babashka/impl/lanterna.clj
@@ -1,0 +1,26 @@
+(ns babashka.impl.lanterna
+  {:no-doc true}
+  (:require
+   [lanterna.screen]
+   [lanterna.terminal]
+   [sci.impl.namespaces :refer [copy-var]]
+   [sci.impl.vars :as vars]))
+
+(def tns (vars/->SciNamespace 'lanterna.terminal nil))
+(def sns (vars/->SciNamespace 'lanterna.screen nil))
+
+(def lanterna-terminal-namespace
+  {'text-terminal (copy-var lanterna.terminal/text-terminal tns)
+   'put-string (copy-var lanterna.terminal/put-string tns)
+   'flush (copy-var lanterna.terminal/flush tns)
+   'clear (copy-var lanterna.terminal/clear tns)
+   'start (copy-var lanterna.terminal/start tns)
+   'stop (copy-var lanterna.terminal/stop tns)})
+
+(def lanterna-screen-namespace
+  ;; TODO
+  {;; 'put-string (copy-var lanterna.screen/put-string sns)
+   ;; 'redraw (copy-var lanterna.screen/redraw sns)
+   ;; 'terminal-screen  (copy-var lanterna.screen/terminal-screen sns)
+   ;; 'start (copy-var lanterna.screen/start sns)
+   })

--- a/feature-lanterna/babashka/impl/lanterna.clj
+++ b/feature-lanterna/babashka/impl/lanterna.clj
@@ -1,6 +1,7 @@
 (ns babashka.impl.lanterna
   {:no-doc true}
   (:require
+   [lanterna.constants]
    [lanterna.screen]
    [lanterna.terminal]
    [sci.impl.namespaces :refer [copy-var]]
@@ -8,19 +9,45 @@
 
 (def tns (vars/->SciNamespace 'lanterna.terminal nil))
 (def sns (vars/->SciNamespace 'lanterna.screen nil))
+(def cns (vars/->SciNamespace 'lanterna.screen nil))
 
 (def lanterna-terminal-namespace
-  {'text-terminal (copy-var lanterna.terminal/text-terminal tns)
-   'put-string (copy-var lanterna.terminal/put-string tns)
-   'flush (copy-var lanterna.terminal/flush tns)
-   'clear (copy-var lanterna.terminal/clear tns)
+  {'add-resize-listener (copy-var lanterna.terminal/add-resize-listener tns)
+   'remove-resize-listener (copy-var lanterna.terminal/remove-resize-listener tns)
+   'text-terminal (copy-var lanterna.terminal/text-terminal tns)
    'start (copy-var lanterna.terminal/start tns)
-   'stop (copy-var lanterna.terminal/stop tns)})
+   'stop (copy-var lanterna.terminal/stop tns)
+   'get-size (copy-var lanterna.terminal/get-size tns)
+   'move-cursor (copy-var lanterna.terminal/move-cursor tns)
+   'put-character (copy-var lanterna.terminal/put-character tns)
+   'put-string (copy-var lanterna.terminal/put-string tns)
+   'clear (copy-var lanterna.terminal/clear tns)
+   'flush (copy-var lanterna.terminal/flush tns)
+   'set-fg-color (copy-var lanterna.terminal/set-fg-color tns)
+   'set-bg-color (copy-var lanterna.terminal/set-bg-color tns)
+   'set-style (copy-var lanterna.terminal/set-style tns)
+   'get-key (copy-var lanterna.terminal/get-key tns)
+   'get-key-blocking (copy-var lanterna.terminal/get-key-blocking tns)})
 
 (def lanterna-screen-namespace
-  ;; TODO
-  {;; 'put-string (copy-var lanterna.screen/put-string sns)
-   ;; 'redraw (copy-var lanterna.screen/redraw sns)
-   ;; 'terminal-screen  (copy-var lanterna.screen/terminal-screen sns)
-   ;; 'start (copy-var lanterna.screen/start sns)
-   })
+  {'terminal-screen (copy-var lanterna.screen/terminal-screen sns)
+   'add-resize-listener (copy-var lanterna.screen/add-resize-listener sns)
+   'remove-resize-listener (copy-var lanterna.screen/remove-resize-listener sns)
+   'start (copy-var lanterna.screen/start sns)
+   'stop (copy-var lanterna.screen/stop sns)
+   'get-size (copy-var lanterna.screen/get-size sns)
+   'redraw (copy-var lanterna.screen/redraw sns)
+   'move-cursor (copy-var lanterna.screen/move-cursor sns)
+   'get-cursor (copy-var lanterna.screen/get-cursor sns)
+   'put-string (copy-var lanterna.screen/put-string sns)
+   'put-sheet (copy-var lanterna.screen/put-sheet sns)
+   'clear (copy-var lanterna.screen/clear sns)
+   'get-key (copy-var lanterna.screen/get-key sns)
+   'get-key-blocking (copy-var lanterna.screen/get-key-blocking sns)})
+
+(def lanterna-constants-namespace
+  {'charsets (copy-var lanterna.constants/charsets cns)
+   'colors (copy-var lanterna.constants/colors cns)
+   'styles (copy-var lanterna.constants/styles cns)
+   'key-codes (copy-var lanterna.constants/key-codes cns)
+   'sgr (copy-var lanterna.constants/sgr cns)})

--- a/project.clj
+++ b/project.clj
@@ -41,7 +41,11 @@
                                       :dependencies [[http-kit "2.5.0"]]}
              :feature/httpkit-server {:source-paths ["feature-httpkit-server"]
                                       :dependencies [[http-kit "2.5.0"]]}
+             :feature/lanterna {:source-paths ["feature-lanterna"]
+                                :dependencies [[babashka/clojure-lanterna "0.9.7"]]}
+
              :test [:feature/xml
+                    :feature/lanterna
                     :feature/yaml
                     :feature/postgresql
                     :feature/hsqldb

--- a/project.clj
+++ b/project.clj
@@ -42,7 +42,7 @@
              :feature/httpkit-server {:source-paths ["feature-httpkit-server"]
                                       :dependencies [[http-kit "2.5.0"]]}
              :feature/lanterna {:source-paths ["feature-lanterna"]
-                                :dependencies [[babashka/clojure-lanterna "0.9.7"]]}
+                                :dependencies [[babashka/clojure-lanterna "0.9.8-SNAPSHOT"]]}
 
              :test [:feature/xml
                     :feature/lanterna

--- a/script/uberjar
+++ b/script/uberjar
@@ -105,6 +105,13 @@ else
     BABASHKA_LEIN_PROFILES+=",-feature/httpkit-server"
 fi
 
+if [ "$BABASHKA_FEATURE_LANTERNA" = "true" ]
+then
+    BABASHKA_LEIN_PROFILES+=",+feature/lanterna"
+else
+    BABASHKA_LEIN_PROFILES+=",-feature/lanterna"
+fi
+
 if [ -z "$BABASHKA_JAR" ]; then
     lein with-profiles "$BABASHKA_LEIN_PROFILES,+reflection,-uberjar" do run
     lein with-profiles "$BABASHKA_LEIN_PROFILES" do clean, uberjar

--- a/script/uberjar.bat
+++ b/script/uberjar.bat
@@ -76,6 +76,12 @@ set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,+feature/httpkit-server
 set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,-feature/httpkit-server
 )
 
+if "%BABASHKA_FEATURE_LANTERNA%"=="true" (
+  set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,+feature/lanterna
+) else (
+  set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,-feature/lanterna
+)
+
 call lein with-profiles %BABASHKA_LEIN_PROFILES% bb "(+ 1 2 3)"
 
 call lein with-profiles %BABASHKA_LEIN_PROFILES%,+reflection,-uberjar do run

--- a/src/babashka/impl/features.clj
+++ b/src/babashka/impl/features.clj
@@ -17,3 +17,4 @@
 (def postgresql? (= "true" (System/getenv "BABASHKA_FEATURE_POSTGRESQL")))
 (def hsqldb? (= "true" (System/getenv "BABASHKA_FEATURE_HSQLDB")))
 (def datascript? (= "true" (System/getenv "BABASHKA_FEATURE_DATASCRIPT")))
+(def lanterna? (= "true" (System/getenv "BABASHKA_FEATURE_LANTERNA")))

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -402,8 +402,9 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
     features/httpkit-client? (assoc 'org.httpkit.client @(resolve 'babashka.impl.httpkit-client/httpkit-client-namespace)
                                     'org.httpkit.sni-client @(resolve 'babashka.impl.httpkit-client/sni-client-namespace))
     features/httpkit-server? (assoc 'org.httpkit.server @(resolve 'babashka.impl.httpkit-server/httpkit-server-namespace))
-    features/lanterna?  (assoc 'lanterna.screen @(resolve 'babashka.impl.lanterna/lanterna-screen-namespace)
-                                 'lanterna.terminal @(resolve 'babashka.impl.lanterna/lanterna-terminal-namespace))))
+    features/lanterna? (assoc 'lanterna.screen @(resolve 'babashka.impl.lanterna/lanterna-screen-namespace)
+                              'lanterna.terminal @(resolve 'babashka.impl.lanterna/lanterna-terminal-namespace)
+                              'lanterna.constants @(resolve 'babashka.impl.lanterna/lanterna-constants-namespace))))
 
 (def imports
   '{ArithmeticException java.lang.ArithmeticException

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -88,6 +88,9 @@
 (when features/httpkit-server?
   (require '[babashka.impl.httpkit-server]))
 
+(when features/lanterna?
+  (require '[babashka.impl.lanterna]))
+
 (sci/alter-var-root sci/in (constantly *in*))
 (sci/alter-var-root sci/out (constantly *out*))
 (sci/alter-var-root sci/err (constantly *err*))
@@ -277,7 +280,8 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
  :feature/jdbc       %s
  :feature/postgresql %s
  :feature/hsqldb     %s
- :feature/httpkit-client %s}")
+ :feature/httpkit-client %s
+ :feature/lanterna %s}")
     version
     features/core-async?
     features/csv?
@@ -288,7 +292,8 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
     features/jdbc?
     features/postgresql?
     features/hsqldb?
-    features/httpkit-client?)))
+    features/httpkit-client?
+    features/lanterna?)))
 
 (defn read-file [file]
   (let [f (io/file file)]
@@ -396,7 +401,9 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
     features/datascript? (assoc 'datascript.core @(resolve 'babashka.impl.datascript/datascript-namespace))
     features/httpkit-client? (assoc 'org.httpkit.client @(resolve 'babashka.impl.httpkit-client/httpkit-client-namespace)
                                     'org.httpkit.sni-client @(resolve 'babashka.impl.httpkit-client/sni-client-namespace))
-    features/httpkit-server? (assoc 'org.httpkit.server @(resolve 'babashka.impl.httpkit-server/httpkit-server-namespace))))
+    features/httpkit-server? (assoc 'org.httpkit.server @(resolve 'babashka.impl.httpkit-server/httpkit-server-namespace))
+    features/lanterna?  (assoc 'lanterna.screen @(resolve 'babashka.impl.lanterna/lanterna-screen-namespace)
+                                 'lanterna.terminal @(resolve 'babashka.impl.lanterna/lanterna-terminal-namespace))))
 
 (def imports
   '{ArithmeticException java.lang.ArithmeticException


### PR DESCRIPTION
When compiling with the env variable `BABASHKA_FEATURE_LANTERNA=true` the following Babashka script can be run, which will start a TUI instance with text.

```clojure
(require '[lanterna.terminal :as terminal])

(def terminal (terminal/text-terminal))

(terminal/start terminal)
(terminal/put-string terminal "Hello TUI Babashka!" 10 5)
(terminal/flush terminal)

(Thread/sleep 1000)
```
### TODO
- [x] Merge https://github.com/babashka/clojure-lanterna/pull/1 and release it on clojars
- [X] Add the rest of the available functions