### PR TITLE
Docker image: Install curl to support babashka.curl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN ./script/uberjar
 RUN ./script/compile
 
 FROM ubuntu:latest
-RUN mkdir -p /usr/local/bin
+RUN apt-get update && apt-get install -y curl \
+        && mkdir -p /usr/local/bin
 COPY --from=BASE /opt/bb /usr/local/bin/bb
 CMD ["bb"]


### PR DESCRIPTION
With the current Ubuntu based docker image it is not possible to use
babashka.curl:

```
> docker run --rm -it borkdude/babashka:0.2.3-SNAPSHOT bb '(-> "https://httpstat.us/200" babashka.curl/get :status)'

----- Error --------------------------------------------------------------------
Type:     java.io.IOException
Message:  Cannot run program "curl": error=2, No such file or directory
Location: <expr>:1:1

----- Context ------------------------------------------------------------------
1: (-> "https://httpstat.us/200" babashka.curl/get :status)
   ^--- Cannot run program "curl": error=2, No such file or directory

----- Stack trace --------------------------------------------------------------
babashka.curl/get - <built-in>
user              - <expr>:1:1
```

After this change it works:

```
> docker run --rm -it hansbugge/babashka bb '(-> "https://httpstat.us/200" babashka.curl/get :status)'
200
```