### PR TITLE
Add feature/oracledb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ org_babashka*.h
 /bb.stripped.pdb
 /.calva
 !test-resources/divide_by_zero.jar
+.envrc

--- a/doc/build.md
+++ b/doc/build.md
@@ -82,6 +82,7 @@ Babashka supports the following feature flags:
 | `BABASHKA_FEATURE_JDBC` | Includes the [next.jdbc](https://github.com/seancorfield/next-jdbc) library | `false`    |
 | `BABASHKA_FEATURE_POSTGRESQL` | Includes the [PostgresSQL](https://jdbc.postgresql.org/) JDBC driver |  `false` |
 | `BABASHKA_FEATURE_HSQLDB` | Includes the [HSQLDB](http://www.hsqldb.org/) JDBC driver | `false` |
+| `BABASHKA_FEATURE_ORACLEDB` | Includes the [Oracle](https://www.oracle.com/database/technologies/appdev/jdbc.html) JDBC driver | `false` |
 | `BABASHKA_FEATURE_DATASCRIPT` | Includes [datascript](https://github.com/tonsky/datascript) | `false` |
 | `BABASHKA_FEATURE_LANTERNA` | Includes [clojure-lanterna](https://github.com/babashka/clojure-lanterna) | `false` |
 

--- a/project.clj
+++ b/project.clj
@@ -29,6 +29,8 @@
              :feature/jdbc {:source-paths ["feature-jdbc"]
                             :dependencies [[seancorfield/next.jdbc "1.1.610"]]}
              :feature/postgresql [:feature/jdbc {:dependencies [[org.postgresql/postgresql "42.2.18"]]}]
+             ;:feature/oracledb [:feature/jdbc {:dependencies [[com.oracle.database.jdbc/ojdbc8 "19.8.0.0"]]}]
+             :feature/oracledb [:feature/jdbc {:dependencies [[io.helidon.integrations.db/ojdbc "2.1.0"]]}] ; ojdbc10 + GraalVM config, by Oracle
              :feature/hsqldb [:feature/jdbc {:dependencies [[org.hsqldb/hsqldb "2.5.1"]]}]
              :feature/core-async {:source-paths ["feature-core-async"]
                                   :dependencies [[org.clojure/core.async "1.3.610"]]}

--- a/script/compile
+++ b/script/compile
@@ -75,6 +75,7 @@ then
     export BABASHKA_FEATURE_JDBC=false
     export BABASHKA_FEATURE_POSTGRESQL=false
     export BABASHKA_FEATURE_HSQLDB=false
+    export BABASHKA_FEATURE_ORACLEDB=false
     export BABASHKA_FEATURE_XML=false
     export BABASHKA_FEATURE_YAML=false
     export BABASHKA_FEATURE_CORE_ASYNC=false

--- a/script/uberjar
+++ b/script/uberjar
@@ -15,6 +15,7 @@ then
     export BABASHKA_FEATURE_JDBC=false
     export BABASHKA_FEATURE_POSTGRESQL=false
     export BABASHKA_FEATURE_HSQLDB=false
+    export BABASHKA_FEATURE_ORACLEDB=false
     export BABASHKA_FEATURE_XML=false
     export BABASHKA_FEATURE_YAML=false
     export BABASHKA_FEATURE_CORE_ASYNC=false
@@ -47,6 +48,13 @@ then
     BABASHKA_LEIN_PROFILES+=",+feature/hsqldb"
 else
     BABASHKA_LEIN_PROFILES+=",-feature/hsqldb"
+fi
+
+if [ "$BABASHKA_FEATURE_ORACLEDB" = "true" ]
+then
+    BABASHKA_LEIN_PROFILES+=",+feature/oracledb"
+else
+    BABASHKA_LEIN_PROFILES+=",-feature/oracledb"
 fi
 
 if [ "$BABASHKA_FEATURE_XML" != "false" ]

--- a/script/uberjar.bat
+++ b/script/uberjar.bat
@@ -28,6 +28,12 @@ if "%BABASHKA_FEATURE_HSQLDB%"=="true" (
   set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,-feature/hsqldb
 )
 
+if "%BABASHKA_FEATURE_ORACLEDB%"=="true" (
+  set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,+feature/oracledb
+) else (
+  set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,-feature/oracledb
+)
+
 if not "%BABASHKA_FEATURE_XML%"=="false" (
   set BABASHKA_LEIN_PROFILES=%BABASHKA_LEIN_PROFILES%,+feature/xml
 ) else (

--- a/src/babashka/impl/features.clj
+++ b/src/babashka/impl/features.clj
@@ -15,6 +15,7 @@
 ;; excluded by default
 (def jdbc? (= "true" (System/getenv "BABASHKA_FEATURE_JDBC")))
 (def postgresql? (= "true" (System/getenv "BABASHKA_FEATURE_POSTGRESQL")))
+(def oracledb? (= "true" (System/getenv "BABASHKA_FEATURE_ORACLEDB")))
 (def hsqldb? (= "true" (System/getenv "BABASHKA_FEATURE_HSQLDB")))
 (def datascript? (= "true" (System/getenv "BABASHKA_FEATURE_DATASCRIPT")))
 (def lanterna? (= "true" (System/getenv "BABASHKA_FEATURE_LANTERNA")))

--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -281,6 +281,7 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
  :feature/jdbc       %s
  :feature/postgresql %s
  :feature/hsqldb     %s
+ :feature/oracledb   %s
  :feature/httpkit-client %s
  :feature/lanterna %s}")
     version
@@ -293,6 +294,7 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
     features/jdbc?
     features/postgresql?
     features/hsqldb?
+    features/oracledb?
     features/httpkit-client?
     features/lanterna?)))
 
@@ -659,5 +661,5 @@ If neither -e, -f, or --socket-repl are specified, then the first argument that 
 
 ;;;; Scratch
 
-(comment
-  )
+(comment)
+


### PR DESCRIPTION
NOTE: Using the Oracle driver directly requires some GraalVM settings
while the helidon wrapper provides those and thus works out of the box.