### PR TITLE
Add the missing class from java.io

### DIFF
--- a/src/babashka/impl/classes.clj
+++ b/src/babashka/impl/classes.clj
@@ -93,8 +93,10 @@
           java.io.FilenameFilter
           java.io.FileNotFoundException
           java.io.InputStream
+          java.io.PipedInputStream
           java.io.IOException
           java.io.OutputStream
+          java.io.PipedOutputStream
           java.io.FileReader
           java.io.InputStreamReader
           java.io.PushbackInputStream

--- a/test/babashka/java_io_piped_stream_test.clj
+++ b/test/babashka/java_io_piped_stream_test.clj
@@ -1,0 +1,12 @@
+(ns babashka.java-io-piped-stream-test
+  (:require [clojure.test :as test :refer [deftest is]])
+  (:import [java.io PipedInputStream PipedOutputStream]))
+
+(deftest piped-stream-test
+  (let [pis (PipedInputStream.)
+        pos (PipedOutputStream.)
+        char-seq [66 97 98 97 115 104 107 97]
+        _ (.connect pis pos)
+        _ (doseq [c char-seq]
+            (.write pos c))]
+    (is (= "Babashka" (apply str (for [_ char-seq] (char (.read pis))))))))


### PR DESCRIPTION
I have use-case that required `java.io.PipedInputStream` and `java.io.PipedOutputStream` in code which is missing from Babashka.

This PR attempt to add these two classes to Babashka.
