### PR TITLE
Add rofi example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -348,7 +348,7 @@ See [torrent-viewer.clj](torrent-viewer.clj).
 
 ### [cprop.clj](cprop.clj)
 
-This script uses [tolitius/cprop](https://github.com/tolitius/cprop) library. 
+This script uses [tolitius/cprop](https://github.com/tolitius/cprop) library.
 
 See [cprop.clj](cprop.clj)
 
@@ -368,4 +368,16 @@ Example usage:
 
 ``` shell
 $ cat src/babashka/main.clj | bb examples/fzf.clj
+```
+
+### [rofi](rofi.clj)
+
+Invoke [rofi](https://github.com/davatorium/rofi), a type-to-filter menu on linux, from babashka.
+
+See [rofi.clj](rofi.clj)
+
+Example usage:
+
+``` shell
+$ cat src/babashka/main.clj | bb examples/rofi.clj
 ```

--- a/examples/rofi.clj
+++ b/examples/rofi.clj
@@ -1,0 +1,12 @@
+(require '[babashka.process :as p])
+
+(defn rofi [s]
+  (let [proc (p/process
+               ["rofi" "-i" "-dmenu" "-mesg" "Select" "-sync" "-p" "*"]
+               {:in  s :err :inherit
+                :out :string})]
+    (:out @proc)))
+
+(rofi (slurp *in*))
+
+;; `echo "hi\nthere\nclj" | bb examples/rofi.clj`


### PR DESCRIPTION
The fzf example inspired me to share [rofi](https://github.com/davatorium/rofi) as a similar use-case - I've leaned heavily into it in my own tooling, mostly with [this wrapper function](https://github.com/russmatney/ralphie/blob/76fed57cda6e729379318791d5ebc1af0dad202d/src/ralphie/rofi.clj#L17). If this is redundant, feel free to close, just thought I'd throw it up here.

Rofi is a linux modal menu for fuzzy filtering, with a similar UX to Alfred or Spotlight on OSX.

Borrows quite directly from the fzf example.