### PR TITLE
feat: add link to turtlequeue/setup-babashka

### DIFF
--- a/doc/libraries.md
+++ b/doc/libraries.md
@@ -387,3 +387,8 @@ An example of using babashka to show spotifyd notifications via dunst.
 ### [nextjournal/ssh-github-auth](https://github.com/nextjournal/ssh-github-auth)
 
 A babashka script which uses github auth to fetch SSH public keys. It can be useful to ensure only a certain team of people can access machines with SSH.
+
+### [turtlequeue/setup-babashka](https://github.com/turtlequeue/setup-babashka)
+
+Github Action to install Babashka in your workflows. Useful to run bb scripts in your CI.
+


### PR DESCRIPTION
As suggested on the clojurians slack, adds a link to https://github.com/turtlequeue/setup-babashka