### PR TITLE
add support for --init command line argument

### DIFF
--- a/test-resources/babashka/init_caller.clj
+++ b/test-resources/babashka/init_caller.clj
@@ -1,0 +1,4 @@
+(ns init-caller
+  (:require [init-test :as i]))
+
+(i/do-a-thing)

--- a/test-resources/babashka/init_test.clj
+++ b/test-resources/babashka/init_test.clj
@@ -1,0 +1,6 @@
+(ns init-test)
+
+(defn do-a-thing [] "foo")
+
+(defn -main [& _]
+  "Hello from init!")

--- a/test-resources/babashka/src_for_classpath_test/call_init_main.clj
+++ b/test-resources/babashka/src_for_classpath_test/call_init_main.clj
@@ -1,0 +1,6 @@
+(ns call-init-main
+  (:require [init-test :as i]))
+
+(defn foobar [] (str (i/do-a-thing) "bar"))
+
+(defn -main [& _] (i/do-a-thing))

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -189,6 +189,26 @@
                                                 (defn bar [x y] (* x y))
                                                 (bar (foo 10 30) 3)))"))))
 
+(deftest init-test
+  (testing "init with a file"
+    (is (= "foo" (bb nil "--init" "test-resources/babashka/init_test.clj" 
+                   "-f" "test-resources/babashka/init_caller.clj"))))
+  (testing "init with eval(s)"
+    (is (= "foo" (bb nil "--init" "test-resources/babashka/init_test.clj"
+                   "-e" "(init-test/do-a-thing)"))))
+  (testing "init with main from init'ed ns"
+    (is (= "Hello from init!" (bb nil "--init" "test-resources/babashka/init_test.clj"
+                                "-m" "init-test"))))
+  (testing "init with main from another namespace"
+    (test-utils/with-config '{:paths ["test-resources/babashka/src_for_classpath_test"]}
+      (is (= "foo" (bb nil "--init" "test-resources/babashka/init_test.clj"
+                     "-m" "call-init-main")))))
+  (testing "init with a qualified function passed to --main"
+    (test-utils/with-config '{:paths ["test-resources/babashka/src_for_classpath_test"]}
+      (is (= "foobar" (bb nil "--init" "test-resources/babashka/init_test.clj"
+                        "-m" "call-init-main/foobar"))))))
+    
+
 (deftest preloads-test
   ;; THIS TEST REQUIRES:
   ;; export BABASHKA_PRELOADS='(defn __bb__foo [] "foo") (defn __bb__bar [] "bar")'


### PR DESCRIPTION
closes #998 

- add `--init` as an arg
- load `--init` file after preloads but before the `-e`/`-f`/`-m` (almost identical to preload handling)
- add init filename to the opts arg to `error-handler` calls (again, sort of mirroring preloads)
- add `--init` to "global opts" section of help
- add tests that combine `--init` and each of the evaluation arg types

to demo the precise use case proposed by #998 (subbing in `bb` for `clojure` with a --init --main command line):
```
$ clojure -M --init init.clj --main foo a b c
Hello from init!
(a b c)
$ bb --init init.clj --main foo a b c
Hello from init!
(a b c)
```
