### PR TITLE
correct --init to be a global option

### DIFF
--- a/src/babashka/main.clj
+++ b/src/babashka/main.clj
@@ -587,10 +587,6 @@ Use bb run --help to show this help output.
           (let [options (next options)]
             (recur (next options)
                    (assoc opts-map :main (first options))))
-          ("--init")
-          (let [options (next options)]
-            (recur (next options)
-                   (assoc opts-map :init (first options))))
           ("--run")
           (parse-run-opts opts-map (next options))
           ("--tasks")
@@ -626,6 +622,8 @@ Use bb run --help to show this help output.
         ("--debug"
          "--verbose" ;; renamed to --debug
          ) (recur (next options) (assoc opts-map :debug true))
+        ("--init")
+        (recur (nnext options) (assoc opts-map :init (second options)))
         [options opts-map])
       [options opts-map])))
 

--- a/test/babashka/main_test.clj
+++ b/test/babashka/main_test.clj
@@ -206,7 +206,17 @@
   (testing "init with a qualified function passed to --main"
     (test-utils/with-config '{:paths ["test-resources/babashka/src_for_classpath_test"]}
       (is (= "foobar" (bb nil "--init" "test-resources/babashka/init_test.clj"
-                        "-m" "call-init-main/foobar"))))))
+                        "-m" "call-init-main/foobar")))))
+  (testing "init with a subcommand after it"
+    (let [actual-output (test-utils/bb "(println (init-test/do-a-thing))"
+                          "--init" "test-resources/babashka/init_test.clj" "repl")]
+      (is (str/includes? actual-output "foo\n")))
+    (test-utils/with-config '{:tasks {thing (println (init-test/do-a-thing))}} ; make a task available 
+      (let [actual-output (test-utils/bb nil "--init" "test-resources/babashka/init_test.clj" "tasks")]
+        (is (every? #(str/includes? actual-output %) ["following tasks are available" "thing"])))))
+  (testing "init with a task name after it"
+    (test-utils/with-config '{:tasks {thing (println (init-test/do-a-thing))}} ; make a task available 
+      (is (= "foo\n" (test-utils/bb nil "--init" "test-resources/babashka/init_test.clj" "thing"))))))
     
 
 (deftest preloads-test


### PR DESCRIPTION
fix for #1035 

Not sure if you want to close the issue or keep it open for thinking about `--preload(s)`.