### PR TITLE
Fix URL for Fluent

### DIFF
--- a/doc/companies.md
+++ b/doc/companies.md
@@ -26,7 +26,7 @@ Sponsoring via [Cognitect](https://www.cognitect.com/).
 
 <img src="https://cdn.nextjournal.com/images/nextjournal-logo.svg" width="300">
 
-### [Fluent](https//fluent.to)
+### [Fluent](https://fluent.to)
 
 <img src="https://uploads-ssl.webflow.com/600fdbbcf0cbfe02f1a48030/600fdf0fffe881c3e8e298f4_Fluent%20logotype-p-500.png" width="300">
 


### PR DESCRIPTION
The url was missing a colon after 'https'.