### PR TITLE
Bump rewrite-clj to v1.0.699-alpha

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -36,7 +36,7 @@
         babashka/clojure-lanterna {:mvn/version "0.9.8-SNAPSHOT"}
         org.clojure/core.match {:mvn/version "1.0.0"}
         hiccup/hiccup {:mvn/version "2.0.0-alpha2"}
-        rewrite-clj/rewrite-clj {:mvn/version "1.0.644-alpha"}
+        rewrite-clj/rewrite-clj {:mvn/version "1.0.699-alpha"}
         selmer/selmer {:mvn/version "1.12.44"}
         com.taoensso/timbre {:mvn/version "5.1.2"}
         org.clojure/tools.logging {:mvn/version "1.1.0"}}


### PR DESCRIPTION
There is a bug in rewrite-clj v644 causing users to be unable to use
`:track-position` and `:auto-resolve` options at the same time in
rewrite zippers. See:

https://github.com/clj-commons/rewrite-clj/issues/159

This makes, for example, building static code analysis tools with
babashka much harder. In fact when analysing code, the position is
relevant for the script output and resolving keywords and symbols might
be required for the analysis.