### PR TITLE
clojure.test: print sci-aware stacktraces in error reports (#1518)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ A preview of the next release can be installed from
 
 ## Unreleased
 
+- [#1518](https://github.com/babashka/babashka/issues/1518): `clojure.test` error reports now include sci-aware stacktraces instead of host JVM frames
 - Add `HexFormat` interop support [#1948]
 - Fix uberscript warnings with `:as-alias` [#1403]
 - SCI: fix `recur` with 20+ args in `loop` [sci#1035](https://github.com/babashka/sci/issues/1035)

--- a/src/babashka/impl/clojure/test.clj
+++ b/src/babashka/impl/clojure/test.clj
@@ -368,7 +368,10 @@
 (defn- print-sci-stack-trace
   "Prints `tr` with a sci-aware stacktrace when one is available, otherwise
   falls back to `clojure.stacktrace/print-cause-trace`. Honors `n` as a
-  maximum number of frames to show per exception in the cause chain."
+  maximum number of frames to show per exception. Walks the cause chain
+  but suppresses host frames on inner causes — the sci frames on the
+  outer wrapper already locate user code, so the host frames on the
+  underlying cause are just noise."
   [^Throwable tr n]
   (if-let [st (sci/stacktrace tr)]
     (let [frames (sci/format-stacktrace st)
@@ -378,9 +381,10 @@
         (when-not (:sci.impl/callstack data)
           (prn data)))
       (run! #(println " " %) frames)
-      (when-let [cause (.getCause tr)]
-        (print "Caused by: ")
-        (print-sci-stack-trace cause n)))
+      (loop [cause (.getCause tr)]
+        (when cause
+          (println (str "Caused by: " (.getName (class cause)) ": " (.getMessage cause)))
+          (recur (.getCause cause)))))
     (stack/print-cause-trace tr n)))
 
 (defmethod report-impl :error [m]

--- a/src/babashka/impl/clojure/test.clj
+++ b/src/babashka/impl/clojure/test.clj
@@ -365,6 +365,24 @@
     (println "expected:" (pr-str (:expected m)))
     (println "  actual:" (pr-str (:actual m)))))
 
+(defn- print-sci-stack-trace
+  "Prints `tr` with a sci-aware stacktrace when one is available, otherwise
+  falls back to `clojure.stacktrace/print-cause-trace`. Honors `n` as a
+  maximum number of frames to show per exception in the cause chain."
+  [^Throwable tr n]
+  (if-let [st (sci/stacktrace tr)]
+    (let [frames (sci/format-stacktrace st)
+          frames (if n (take n frames) frames)]
+      (println (str (.getName (class tr)) ": " (.getMessage tr)))
+      (when-let [data (ex-data tr)]
+        (when-not (:sci.impl/callstack data)
+          (prn data)))
+      (run! #(println " " %) frames)
+      (when-let [cause (.getCause tr)]
+        (print "Caused by: ")
+        (print-sci-stack-trace cause n)))
+    (stack/print-cause-trace tr n)))
+
 (defmethod report-impl :error [m]
   (with-test-out-internal
     (inc-report-counter :error)
@@ -375,7 +393,7 @@
     (print "  actual: ")
     (let [actual (:actual m)]
       (if (instance? Throwable actual)
-        (stack/print-cause-trace actual @stack-trace-depth)
+        (print-sci-stack-trace actual @stack-trace-depth)
         (prn actual)))))
 
 (defmethod report-impl :summary [m]
@@ -540,7 +558,7 @@
   {:added "1.1"}
   [msg form]
   `(try ~(assert-expr msg form)
-        (catch Throwable t#
+        (catch ~(with-meta 'Throwable {:sci/error true}) t#
           (clojure.test/do-report {:file clojure.core/*file*
                                    :line ~(:line (meta form))
                                    :type :error, :message ~msg,

--- a/test/babashka/test_test.clj
+++ b/test/babashka/test_test.clj
@@ -125,3 +125,15 @@ true")))))
         (bb "(clojure.test/testing-vars-str {:file \"x\" :line 1})")
         "() (x:1)")
       "includes explicit line number + file name in test report"))
+
+(deftest error-report-sci-stacktrace-test
+  (let [output (bb "(require '[clojure.test :as t])
+                    (defn myfun [] (throw (Exception. \"boom\")))
+                    (t/deftest tst (t/is (= 0 (myfun))))
+                    (t/run-tests *ns*)")]
+    (is (str/includes? output "java.lang.Exception: boom")
+        "prints the exception class and message")
+    (is (str/includes? output "user/myfun")
+        "includes sci frame for the user function")
+    (is (not (str/includes? output "sci.impl.Reflector"))
+        "does not leak host JVM frames")))


### PR DESCRIPTION
Annotate try-expr's catch with `^{:sci/error true}` so sci attaches :sci.impl/callstack to the caught exception, then route the `:error` reporter through sci/stacktrace + sci/format-stacktrace. Falls back to `clojure.stacktrace/print-cause-trace` when no sci callstack is present. Honors `*stack-trace-depth*` and walks the cause chain.

Builds on the original WIP exploration in #1519 by @pesterhazy.

